### PR TITLE
feat(requests): add timeout policy

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -4,7 +4,7 @@ const http = require('http');
  * Alguien nos dejó esta implementación de un GET en node.
  * ¡No cambiar interfaz!
  */
-function get(servicio, ruta, cb) {
+function get(servicio, ruta, cb, timeout=2000) {
     const opciones = {
         hostname: servicio.host,
         port: servicio.puerto,
@@ -29,9 +29,16 @@ function get(servicio, ruta, cb) {
                 }
             });
     });
+
     req.on('error', error => {
         cb(error);
     });
+    
+    req.setTimeout(timeout, () => {
+        req.destroy();
+        cb(new Error(`Timeout al conectar con ${servicio.nombre}${ruta} después de ${timeout}ms`));
+    });
+    
     req.end();
 }
 


### PR DESCRIPTION
Con esto, se puede configurar timeouts customs y no heredar los de un servicio externo. 
Cuando `cuando-viene`, consulta las `paradas` tenia el mismo tiemout que el middleware https://github.com/DylanLosada/practica-cps-promises-cuando-viene/blob/34115155082a42eba8736c2c1d3d1aee2df5478a/src/paradas/paradas.js#L10
5 segs
https://github.com/DylanLosada/practica-cps-promises-cuando-viene/blob/34115155082a42eba8736c2c1d3d1aee2df5478a/src/middleware.js#L14

Con este cambio pasa a ser 2 seg, por default